### PR TITLE
Suggest deliverables from the research query

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,17 @@ VALYU_API_KEY=valyu_your_api_key_here
 # ------------------------------------------------------------------------------
 # OPENAI API (OPTIONAL - for fallback when local models unavailable)
 # ------------------------------------------------------------------------------
-# Used for AI chat responses when Ollama/LM Studio not available
+# Used for AI chat responses when Ollama/LM Studio not available, and for the
+# deliverable extractor that reads a research query and proposes the files it
+# implies. Without a valid key the extractor stays off and the deliverables
+# picker behaves as a purely manual control - research itself is unaffected.
 # Get your API key at: https://platform.openai.com
 OPENAI_API_KEY=sk-your_openai_api_key_here
+
+# Model behind the deliverable extractor. Optional - defaults to gpt-5.6-luna.
+# Must support strict structured outputs; a model that returns a bare array
+# instead of the expected object is rejected and yields no suggestion.
+# DELIVERABLE_SUGGEST_MODEL=gpt-5.6-luna
 
 # ------------------------------------------------------------------------------
 # DAYTONA API (REQUIRED)

--- a/src/app/api/deliverables/suggest/route.ts
+++ b/src/app/api/deliverables/suggest/route.ts
@@ -1,0 +1,28 @@
+import { suggestDeliverables } from "@/lib/deliverable-suggest";
+
+const json = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/**
+ * POST /api/deliverables/suggest - propose deliverables for a freeform query.
+ *
+ * Advisory only: the client pre-fills the deliverables picker with whatever
+ * comes back and the user edits it before launching. Nothing here starts a run
+ * or spends Valyu credits, so it needs no Valyu token.
+ *
+ * Always answers 200 with a (possibly empty) list. The caller is on the typing
+ * path, and a failed suggestion must degrade to "no suggestions" rather than
+ * surface an error next to the user's query.
+ */
+export async function POST(req: Request) {
+  try {
+    const { query } = await req.json();
+    if (typeof query !== "string") return json({ suggestions: [] });
+    return json({ suggestions: await suggestDeliverables(query) });
+  } catch {
+    return json({ suggestions: [] });
+  }
+}

--- a/src/components/research-chat.tsx
+++ b/src/components/research-chat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -8,7 +8,7 @@ import { motion } from "framer-motion";
 import { ArrowRight, Loader2, Plus, Ban, Zap, BarChart3, Terminal, FileSpreadsheet, AlertCircle, X, ChevronDown } from "lucide-react";
 import { MODES } from "@/lib/domains";
 import { isTerminal } from "@/lib/reports";
-import { apiCreateResearch, apiSyncReport, apiCancelReport } from "@/lib/report-client";
+import { apiCreateResearch, apiSyncReport, apiCancelReport, apiSuggestDeliverables } from "@/lib/report-client";
 import type { DeliverableType, DeliverableItem } from "@/lib/report-client";
 import { requestNotifyPermission } from "@/lib/report-notify";
 import { ReportView } from "@/components/reports/report-view";
@@ -68,8 +68,29 @@ const SAMPLE_DESC: Record<DeliverableType, string> = Object.fromEntries(
   DELIVERABLE_FORMATS.map((f) => [f.type, f.sample]),
 ) as Record<DeliverableType, string>;
 
+/** Short names for the launch status line - "an Excel file", "2 files". */
+const SHORT_LABEL: Record<DeliverableType, string> = {
+  xlsx: "an Excel file",
+  pptx: "a PowerPoint deck",
+  docx: "a Word document",
+  csv: "a CSV table",
+  pdf: "a PDF",
+};
+
+const describeDeliverables = (items: DeliverableItem[]) =>
+  items.length === 1 ? SHORT_LABEL[items[0].type] : `${items.length} files`;
+
 const OFFICE_FORMATS: DeliverableType[] = ["xlsx", "pptx", "docx"];
 const isOfficeFormat = (type: DeliverableType) => OFFICE_FORMATS.includes(type);
+
+/** Shortest query worth reasoning about; mirrors the server-side gate. */
+const MIN_SUGGEST_LENGTH = 20;
+/** Let typing settle before spending a model call on it. */
+const SUGGEST_DEBOUNCE_MS = 800;
+/** Tighter ceiling for the catch-up call on submit: this one is the only thing
+ *  standing between the user and their run, so it gives up sooner and launches
+ *  without a deliverable rather than leaving them staring at a spinner. */
+const LATE_SUGGEST_TIMEOUT_MS = 4000;
 
 /**
  * Homepage research surface. A freeform query launches a Valyu DeepResearch
@@ -107,11 +128,16 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
   }>({ charts: true, codeExecution: false, deliverables: [] });
   const [deliverablesOpen, setDeliverablesOpen] = useState(false);
   const [launching, setLaunching] = useState(false);
+  // What the launch is doing right now. The button spinner says "something is
+  // happening"; this says what - and on the paste-and-Enter path it is the only
+  // chance the user gets to see a deliverable being attached on their behalf.
+  const [launchNote, setLaunchNote] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Office deliverables (xlsx/pptx/docx) are produced via code execution, so
   // requesting any of them implies it (reflected in the Code Execution pill).
   const hasOfficeDeliverable = tools.deliverables.some((d) => isOfficeFormat(d.type));
+  const hasSuggestion = tools.deliverables.some((d) => d.suggested);
 
   const toggleTool = (key: "charts" | "codeExecution") =>
     setTools((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -125,10 +151,14 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
         : { ...prev, deliverables: [...prev.deliverables, { type: "xlsx", description: "" }] },
     );
 
+  // Editing a row makes it the user's, not the extractor's: drop the suggested
+  // flag so it loses the badge and stops being eligible for replacement.
   const updateDeliverable = (i: number, patch: Partial<DeliverableItem>) =>
     setTools((prev) => ({
       ...prev,
-      deliverables: prev.deliverables.map((d, idx) => (idx === i ? { ...d, ...patch } : d)),
+      deliverables: prev.deliverables.map((d, idx) =>
+        idx === i ? { ...d, ...patch, suggested: false } : d,
+      ),
     }));
 
   const removeDeliverable = (i: number) =>
@@ -145,6 +175,85 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
     setDeliverablesOpen(willOpen);
     if (willOpen && tools.deliverables.length === 0) addDeliverable();
   };
+  // ---- Deliverable suggestions --------------------------------------------
+  // A query often names the artifact it wants ("...as an Excel spreadsheet"),
+  // but the picker below was the only way to actually request one - so the file
+  // was quietly never produced. A small model reads the settled query and
+  // pre-fills the picker with a format AND a description drawn from the query
+  // itself, which is the field that steers what ends up in the file.
+  //
+  // Seeded, never imposed: suggestions land in the opened panel where they can
+  // be edited or removed, because a deliverable costs credits and time.
+
+  // Lets the async callback read the live list without making the effect depend
+  // on `tools` - which would re-fire it on every edit the user makes.
+  const deliverablesRef = useRef(tools.deliverables);
+  deliverablesRef.current = tools.deliverables;
+  // Last query suggested for. Stops a re-fire, and stops us re-opening a panel
+  // the user just closed, while the query itself is unchanged.
+  const suggestedForRef = useRef<string | null>(null);
+
+  // A suggestion belongs to the query it came from. Left attached when the
+  // query moves on, it would produce a file about the wrong subject and bill
+  // for it - so drop ours whenever they stop matching. Rows the user wrote are
+  // theirs and always stay.
+  const dropStaleSuggestions = () => {
+    const kept = deliverablesRef.current.filter((d) => !d.suggested);
+    if (kept.length === deliverablesRef.current.length) return;
+    setTools((prev) => ({ ...prev, deliverables: kept }));
+    // Nothing left means everything in the panel was ours, so close what we
+    // opened rather than leaving an empty tray behind.
+    if (kept.length === 0) setDeliverablesOpen(false);
+  };
+
+  useEffect(() => {
+    if (launching) return;
+    const q = input.trim();
+
+    // Query cleared or trimmed back to a fragment: nothing here to justify a
+    // deliverable. Reset the memo too, so retyping the same query re-suggests.
+    if (q.length < MIN_SUGGEST_LENGTH) {
+      dropStaleSuggestions();
+      suggestedForRef.current = null;
+      return;
+    }
+    if (suggestedForRef.current === q) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      const suggestions = await apiSuggestDeliverables(q, controller.signal);
+      if (controller.signal.aborted) return;
+      suggestedForRef.current = q;
+      // The new query warrants no file - so neither does the old one's leftover.
+      if (suggestions.length === 0) {
+        dropStaleSuggestions();
+        return;
+      }
+
+      // Only fill space the user hasn't claimed. A row they typed a description
+      // into is theirs and blocks the fill; a pristine row seeded by opening the
+      // panel is not - replacing that one is the point, since a blank
+      // description falls through to a generic default server-side.
+      const canFill = deliverablesRef.current.every(
+        (d) => d.suggested || !d.description.trim(),
+      );
+      if (!canFill) return;
+
+      setTools((prev) => ({
+        ...prev,
+        deliverables: suggestions.slice(0, MAX_DELIVERABLES),
+      }));
+      // Open the panel: what the run will produce should be visible before it
+      // is launched, not discovered afterwards on the bill.
+      setDeliverablesOpen(true);
+    }, SUGGEST_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [input, launching]);
+
   // Synchronous re-entrancy guard. The `launching` state can't block a second
   // submit() fired in the same tick (rapid double-click / double-Enter) because
   // React hasn't re-rendered yet — without this, one fumble = two runs = double
@@ -161,15 +270,47 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
     // (it's a long async run — the user will likely switch away).
     void requestNotifyPermission();
     try {
+      // Paste-and-Enter is the common way in, and it outruns the debounce: the
+      // extractor may never have seen this query. Resolve it here rather than
+      // dropping a file the query explicitly asked for. Only the impatient path
+      // pays the wait - anyone who pauses to read already has their suggestion.
+      setLaunchNote("Starting research…");
+      let deliverables = deliverablesRef.current;
+      if (suggestedForRef.current !== q) {
+        const unclaimed = deliverables.every((d) => d.suggested || !d.description.trim());
+        if (unclaimed) {
+          setLaunchNote("Checking what files this needs…");
+          const late = await apiSuggestDeliverables(q, AbortSignal.timeout(LATE_SUGGEST_TIMEOUT_MS));
+          // This query is now resolved. Without recording it, a failed launch
+          // re-enables the debounced effect and pays for the same call twice.
+          suggestedForRef.current = q;
+          if (late.length > 0) {
+            deliverables = late.slice(0, MAX_DELIVERABLES);
+            // Reflected in state so a failed launch shows what would have been
+            // attached, instead of silently retrying with a different payload.
+            setTools((prev) => ({ ...prev, deliverables }));
+            // Open the panel even though we are about to navigate: attaching a
+            // file the user never saw requested is the thing to avoid, and on a
+            // failed launch this is what they come back to.
+            setDeliverablesOpen(true);
+            setLaunchNote(`Adding ${describeDeliverables(deliverables)} — starting research…`);
+          } else {
+            setLaunchNote("Starting research…");
+          }
+        }
+      }
+
       const report = await apiCreateResearch(q, mode, {
         charts: tools.charts,
-        codeExecution: tools.codeExecution || hasOfficeDeliverable,
-        deliverables: tools.deliverables,
+        codeExecution:
+          tools.codeExecution || deliverables.some((d) => isOfficeFormat(d.type)),
+        deliverables,
       });
       onLaunched(report.id); // navigates away (unmounts) on success
     } catch (e) {
       setError((e as Error).message);
       setLaunching(false);
+      setLaunchNote(null); // the error replaces the status line
       submittingRef.current = false; // allow retry after a failure
     }
   };
@@ -205,6 +346,19 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
             {launching ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
           </button>
         </div>
+
+        {/* Launch status. The spinner says "working"; this says what - and names
+            any file being attached, so nothing is added out of sight. */}
+        {launching && launchNote && (
+          <p
+            role="status"
+            aria-live="polite"
+            className="mt-2 flex items-center gap-1.5 text-[11px] text-muted-foreground"
+          >
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {launchNote}
+          </p>
+        )}
 
         {/* Depth + Tools — two labeled sub-groups on a single wrapping row */}
         <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4">
@@ -288,7 +442,9 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
             <div className="flex items-center justify-between mb-2.5">
               <span className="text-[11px] font-medium text-foreground">Deliverables</span>
               <span className="text-[10px] text-muted-foreground/70">
-                Pick a format and describe what it should contain
+                {hasSuggestion
+                  ? "Suggested from your query — edit or remove before running"
+                  : "Pick a format and describe what it should contain"}
               </span>
             </div>
 
@@ -322,13 +478,22 @@ function ResearchInput({ onLaunched }: { onLaunched: (id: string) => void }) {
                       ))}
                     </SelectContent>
                   </Select>
-                  <input
-                    value={d.description}
-                    onChange={(e) => updateDeliverable(i, { description: e.target.value })}
-                    placeholder={SAMPLE_DESC[d.type]}
-                    maxLength={500}
-                    className="flex-1 min-w-0 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-muted-foreground/40"
-                  />
+                  <div className="relative flex-1 min-w-0">
+                    <input
+                      value={d.description}
+                      onChange={(e) => updateDeliverable(i, { description: e.target.value })}
+                      placeholder={SAMPLE_DESC[d.type]}
+                      maxLength={500}
+                      className={`w-full rounded-lg border border-border bg-background py-1.5 pl-2.5 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-muted-foreground/40 ${
+                        d.suggested ? "pr-[76px]" : "pr-2.5"
+                      }`}
+                    />
+                    {d.suggested && (
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide bg-muted text-muted-foreground/80">
+                        Suggested
+                      </span>
+                    )}
+                  </div>
                   <button
                     onClick={() => removeDeliverable(i)}
                     aria-label="Remove deliverable"

--- a/src/lib/deliverable-suggest.ts
+++ b/src/lib/deliverable-suggest.ts
@@ -137,6 +137,10 @@ export async function suggestDeliverables(
       system: SYSTEM_PROMPT,
       prompt: `Request: ${trimmed.slice(0, MAX_QUERY_CHARS)}`,
       temperature: 0,
+      // Classifying one sentence needs no deliberation, and this call sits on
+      // the path between the user and their run. Ignored by non-reasoning
+      // models, so it is safe whichever model is configured.
+      providerOptions: { openai: { reasoningEffort: "none" } },
       abortSignal: AbortSignal.timeout(TIMEOUT_MS),
     });
 

--- a/src/lib/deliverable-suggest.ts
+++ b/src/lib/deliverable-suggest.ts
@@ -1,0 +1,166 @@
+/**
+ * Small-model extractor that turns a freeform research query into suggested
+ * deliverables (format + description).
+ *
+ * Two gaps this closes, both seen in real runs:
+ *  - A query that asks for a file in plain English ("...as an Excel spreadsheet
+ *    I can drop into a deck") produces no deliverable at all, because the only
+ *    way to request one is the picker.
+ *  - A picker row left with an empty description falls back to a generic
+ *    DEFAULT_DELIVERABLE_DESC string, so the run is steered by "Key figures and
+ *    supporting data as a spreadsheet" instead of by what was actually asked.
+ *
+ * The description is the part that matters: the DeepResearch API uses it to
+ * decide what goes in the file. Suggestions are advisory - the UI pre-fills the
+ * picker and the user edits or removes them before launching.
+ *
+ * Fails open by design. A missing key, a timeout, or a malformed response all
+ * yield an empty list: a research launch must never be blocked by this.
+ */
+
+import { generateObject } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import { z } from "zod";
+
+/** Formats worth suggesting. `pdf` is deliberately absent: every run already
+ *  requests a PDF via `output_formats` and renders an "Open PDF" button, so
+ *  suggesting one duplicates a file the user gets anyway. */
+const SUGGESTIBLE_TYPES = ["csv", "xlsx", "pptx", "docx"] as const;
+
+export type SuggestibleType = (typeof SUGGESTIBLE_TYPES)[number];
+
+export interface DeliverableSuggestion {
+  type: SuggestibleType;
+  description: string;
+}
+
+/** Cap suggestions well below the picker's own limit of 5. The extractor should
+ *  seed a starting point, not fill the panel on the user's behalf. */
+const MAX_SUGGESTIONS = 3;
+
+/** Below this, a query is a ticker or a fragment - not enough to reason about. */
+export const MIN_QUERY_LENGTH = 20;
+
+/** Generous on purpose. This runs in the background while the user is still
+ *  typing and blocks nothing, so a tight budget buys nothing but lost
+ *  suggestions: measured latency is ~1.5s typical but tails past 4s when the
+ *  server is also servicing a history poll, and earlier 2s/6s ceilings both
+ *  timed out in practice. The client aborts this call the moment a run is
+ *  launched, so a late answer can never affect one. */
+const TIMEOUT_MS = 10000;
+
+/** Descriptions longer than this get truncated rather than rejected. */
+const MAX_DESCRIPTION_LENGTH = 200;
+
+/** Only the query's leading characters are used - a bound on tokens, and on
+ *  what an unauthenticated caller can push through the model. */
+const MAX_QUERY_CHARS = 1000;
+
+const model = process.env.DELIVERABLE_SUGGEST_MODEL || "gpt-4o-mini";
+
+/**
+ * Kept permissive on purpose. `generateObject` throws when the model's output
+ * fails the schema, and a throw here costs every suggestion - so bounds like
+ * "at most 3" and "at most 200 chars" are enforced in code below rather than
+ * as validation that can fail the whole call.
+ */
+const suggestionSchema = z.object({
+  suggestions: z.array(
+    z.object({
+      type: z.enum(SUGGESTIBLE_TYPES),
+      description: z.string(),
+    }),
+  ),
+});
+
+const SYSTEM_PROMPT = `You decide whether a financial research request implies the user wants a downloadable file, and if so, what should go in it.
+
+Suggest a deliverable ONLY when the request implies a tangible artifact:
+- xlsx: a financial model, or data spanning multiple tabs/sheets
+- csv: a single flat table of data
+- pptx: a deck, presentation, or set of slides
+- docx: a written memo, report, or document
+
+Return an EMPTY list when the request just wants an answer, a number, an explanation, or a view. That is the common case - most research questions need no file. Be conservative: a wrong suggestion costs the user credits and time.
+
+When you do suggest one, the description is the important part. It is passed to the research engine to steer what the file contains.
+- Name the actual companies, tickers, metrics and periods from the request.
+- Describe the CONTENTS, not the format.
+- One sentence, under 200 characters.
+- Never write something generic like "key figures and supporting data" or "the underlying data" - a description that would fit any query is worse than no suggestion.
+
+Suggest at most 3, and usually 0 or 1. Only suggest multiple when the request genuinely asks for distinct artifacts.
+
+Always answer with an object holding a "suggestions" array - never a bare array,
+even when there is nothing to suggest.
+
+Examples:
+
+Request: "What was Alphabet's 2026 capex guidance?"
+(a question; wants an answer, not a file)
+{"suggestions": []}
+
+Request: "How is Nvidia positioned against AMD in data center GPUs?"
+(wants analysis, not a file)
+{"suggestions": []}
+
+Request: "Build me a peer comps table for Alphabet vs Microsoft and Meta - EV/EBITDA, P/E and revenue growth - as an Excel spreadsheet"
+{"suggestions": [{"type": "xlsx", "description": "Peer comparables table for GOOGL, MSFT and META with EV/EBITDA, P/E and revenue growth"}]}
+
+Request: "3-statement model for Shopify through 2028"
+{"suggestions": [{"type": "xlsx", "description": "Three-statement model for Shopify with income statement, balance sheet and cash flow projected through 2028"}]}
+
+Request: "Put together an IC memo on Stripe with a recommendation, plus slides for the partner meeting"
+{"suggestions": [{"type": "docx", "description": "Investment committee memo on Stripe covering thesis, valuation, risks and a recommendation"}, {"type": "pptx", "description": "Partner meeting deck for Stripe summarising the thesis, key metrics and recommendation"}]}`;
+
+/**
+ * Suggest deliverables for a freeform research query.
+ * Returns `[]` for anything that doesn't clearly warrant a file, and for every
+ * failure mode (no API key, timeout, model error, unparseable output).
+ */
+export async function suggestDeliverables(
+  query: string,
+): Promise<DeliverableSuggestion[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_QUERY_LENGTH) return [];
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  // No key is a normal state in self-hosted mode, not an error - the feature
+  // just stays dark and the picker behaves exactly as it did before.
+  if (!apiKey) return [];
+
+  try {
+    const openai = createOpenAI({ apiKey });
+    const { object } = await generateObject({
+      model: openai(model),
+      schema: suggestionSchema,
+      system: SYSTEM_PROMPT,
+      prompt: `Request: ${trimmed.slice(0, MAX_QUERY_CHARS)}`,
+      temperature: 0,
+      abortSignal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+
+    return (object.suggestions ?? [])
+      .map((s) => ({
+        type: s.type,
+        description: s.description.trim().slice(0, MAX_DESCRIPTION_LENGTH),
+      }))
+      // A blank description is worse than no suggestion: it would fall through
+      // to the same generic default this feature exists to avoid.
+      .filter((s) => s.description.length > 0)
+      .slice(0, MAX_SUGGESTIONS);
+  } catch (e) {
+    // Fail open, but not silently: swallowing this whole made a dead API key
+    // look identical to "nothing worth suggesting". The user still gets a
+    // clean launch; the operator gets a reason in the server log.
+    // The cause carries the detail worth having: a schema mismatch shows up
+    // here as a validation failure, which is otherwise indistinguishable from
+    // "nothing to suggest".
+    console.warn(
+      "[deliverable-suggest] suggestion failed, continuing without one:",
+      e instanceof Error ? e.message : e,
+      (e as { cause?: { message?: string } })?.cause?.message ?? "",
+    );
+    return [];
+  }
+}

--- a/src/lib/deliverable-suggest.ts
+++ b/src/lib/deliverable-suggest.ts
@@ -56,7 +56,11 @@ const MAX_DESCRIPTION_LENGTH = 200;
  *  what an unauthenticated caller can push through the model. */
 const MAX_QUERY_CHARS = 1000;
 
-const model = process.env.DELIVERABLE_SUGGEST_MODEL || "gpt-4o-mini";
+/** Small model is the point - this runs on every settled query. Override with
+ *  DELIVERABLE_SUGGEST_MODEL. Whatever you pick must support strict structured
+ *  outputs: the schema below is enforced, and a model that answers with a bare
+ *  array instead of the wrapper object gets rejected as a refusal. */
+const model = process.env.DELIVERABLE_SUGGEST_MODEL || "gpt-5.6-luna";
 
 /**
  * Kept permissive on purpose. `generateObject` throws when the model's output

--- a/src/lib/report-client.ts
+++ b/src/lib/report-client.ts
@@ -101,6 +101,10 @@ export type DeliverableType = "csv" | "xlsx" | "pptx" | "docx" | "pdf";
 export interface DeliverableItem {
   type: DeliverableType;
   description: string;
+  /** Proposed by the extractor rather than typed by the user. Drives the UI
+   *  only: it travels as far as our own launch route, which maps deliverables
+   *  field by field, so it never reaches Valyu. Cleared when the row is edited. */
+  suggested?: boolean;
 }
 
 /** Optional research enhancements toggled per run. */
@@ -108,6 +112,36 @@ export interface ResearchTools {
   charts?: boolean;
   codeExecution?: boolean;
   deliverables?: DeliverableItem[];
+}
+
+/**
+ * Ask the server which deliverables (if any) a query implies, so the picker can
+ * be pre-filled with a format AND a description written from the query itself.
+ *
+ * Advisory and best-effort: never throws, and answers `[]` whenever the
+ * extractor is unavailable. Callers treat that as "no suggestion" and carry on.
+ */
+export async function apiSuggestDeliverables(
+  query: string,
+  signal?: AbortSignal,
+): Promise<DeliverableItem[]> {
+  try {
+    const res = await fetch("/api/deliverables/suggest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+      signal,
+    });
+    if (!res.ok) return [];
+    const json = await res.json();
+    return (json.suggestions ?? []).map((s: { type: DeliverableType; description: string }) => ({
+      type: s.type,
+      description: s.description,
+      suggested: true,
+    }));
+  } catch {
+    return [];
+  }
 }
 
 /** Launch a freeform DeepResearch run from a chat query. */


### PR DESCRIPTION
## Why

A query often names the artifact it wants — "…as an Excel spreadsheet I can drop into a deck" — but the deliverables picker was the only way to actually request one, so the file was quietly never produced. Verified before this change: that exact query completed a full run and produced zero deliverables.

The second half of the problem is the description field. It is what the DeepResearch API uses to decide what goes in the file, and it is the part users skip. A blank row falls back to a generic default, so a run gets steered by "Key figures and supporting data as a spreadsheet" instead of by what was asked.

## What

A small model reads the settled query and pre-fills the picker with a format **and** a description drawn from the query itself. Suggestions are seeded, not imposed — they land in the opened panel, badged `SUGGESTED`, and can be edited or removed before launching, because a deliverable costs credits and time.

- `src/lib/deliverable-suggest.ts` — zod schema + `generateObject` over the existing `@ai-sdk/openai` dependency. No new packages. Model overridable via `DELIVERABLE_SUGGEST_MODEL`.
- `src/app/api/deliverables/suggest/route.ts` — always answers 200 with a possibly-empty list. Spends no Valyu credits, so no Valyu token needed.
- `report-client.ts` / `research-chat.tsx` — debounced call on the settled query, aborted when the query changes or a run launches.

Behaviour worth reviewing:

- Suggestions are dropped when the query moves on or is cleared, so a previous query's file cannot ride along onto an unrelated one.
- Rows the user typed into are never touched.
- Paste-and-Enter outruns the debounce, so `submit()` resolves the query before launching rather than dropping a file that was asked for. Costs ~1.3–2.5s on that path only.
- A status line names the step and names any file being attached, so nothing is added out of sight.
- Fails open throughout: no API key, a timeout, or a bad response all mean "no suggestion", never a blocked launch.
- `pdf` is deliberately not suggestible — every run already emits one via `output_formats`.

## Verification

- Extractor matrix, 14 queries: 8 correct positives (xlsx / csv / docx / docx+pptx), 6 correct empties on questions and bare tickers.
- Launch payload captured on paste-and-Enter: `deliverables: [{type: "xlsx", …}]` with `codeExecution: true` auto-enabled; a pure question sends `[]` and `false`.
- End-to-end run produced a 3×9 peer comps sheet from a query that previously produced nothing.
- Stale-drop, clear-and-retype, user-edit protection, suggestion replacement, and the failed-launch path all covered.
- `tsc --noEmit`, ESLint, and `pnpm build` clean.

Two fixes worth calling out, both caught by the fail-open warning that logs the reason instead of swallowing it:

1. Few-shot examples were written as bare arrays, so the model returned a bare array against a strict `json_schema` and OpenAI classified it as a refusal — silently failing ~4 in 6 multi-deliverable calls. Examples now show the wrapper object; 10/10 after.
2. The submit-path catch-up did not record that it had resolved a query, so a failed launch paid for the same call twice.

## Not included

The workflow launch path still sends no `tools`, so the deliverable badges on workflow cards remain unverified against a real run. Left out deliberately — separate problem.