### PR TITLE
Show deliverables at the top of a finished report

### DIFF
--- a/src/components/reports/report-artifacts.tsx
+++ b/src/components/reports/report-artifacts.tsx
@@ -82,7 +82,7 @@ export function DeliverablesList({ deliverables }: { deliverables: ResearchDeliv
   if (!usable.length) return null;
 
   return (
-    <section className="mt-6">
+    <section className="mb-4">
       <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground mb-3">
         Deliverables
       </h2>

--- a/src/components/reports/report-view.tsx
+++ b/src/components/reports/report-view.tsx
@@ -256,7 +256,13 @@ export function ReportView({ reportId }: { reportId: string }) {
         </div>
       )}
 
-      {/* Completed — research activity (collapsed) then the report */}
+      {/* Completed — the files first. They are the thing a finished report is
+          often opened for, and buried under the body they were easy to miss. */}
+      {report.status === "completed" && report.deliverables && report.deliverables.length > 0 && (
+        <DeliverablesList deliverables={report.deliverables} />
+      )}
+
+      {/* Research activity (collapsed) then the report */}
       {report.status === "completed" && report.activity && report.activity.length > 0 && (
         <details className="mb-4 rounded-2xl border border-border bg-card overflow-hidden group">
           <summary className="cursor-pointer list-none px-5 py-3 text-sm font-medium text-foreground flex items-center justify-between hover:bg-muted/30">
@@ -289,9 +295,6 @@ export function ReportView({ reportId }: { reportId: string }) {
 
       {report.status === "completed" && report.images && report.images.length > 0 && (
         <ChartGallery images={report.images} />
-      )}
-      {report.status === "completed" && report.deliverables && report.deliverables.length > 0 && (
-        <DeliverablesList deliverables={report.deliverables} />
       )}
 
       <AuthModal open={showAuthModal} onClose={() => setShowAuthModal(false)} />


### PR DESCRIPTION
## Why

Generated files rendered **last** in the report view — below the entire report body and the chart gallery. On a long report that put them several screens down, so they were easy to miss entirely. They are frequently the reason a finished report gets opened in the first place.

## What

`DeliverablesList` moves to directly under the report title, above the collapsed activity block and the body.

New order: **title → DELIVERABLES → Research activity → report body → charts**

One supporting change: the component carried `mt-6`, sized for its old trailing position, which at the top left a gap above it and nothing below — it collided with the activity bar. Swapped for `mb-4` to match the block beneath. Safe because the component has exactly one render site.

Charts deliberately stay where they are. They illustrate the analysis and read naturally alongside it; the files are the takeaway.

## Verification

Checked against a real completed report (a workflow run producing `Buyer list… Excel · 14×12`):

- Section order in the DOM is now `["DELIVERABLES", "RESEARCH ACTIVITY", "Executive Summary", "Sources"]`
- The heading measures at **209px** in a 720px viewport — above the fold with no scrolling, which is the point
- Screenshot confirms placement directly beneath the title

`tsc --noEmit` exit 0 and `pnpm build` compiles.

## Note

`report-view.tsx` has a pre-existing `react-hooks/exhaustive-deps` warning at line 87. Confirmed by stashing that it is present on `main` independently of this change, so it is left alone rather than widening the diff.